### PR TITLE
PR for take home exercise glucose dashboard

### DIFF
--- a/app/controllers/api/v1/metrics_controller.rb
+++ b/app/controllers/api/v1/metrics_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::MetricsController < ApplicationController
+  def show
+    member = Member.find(params[:member_id])
+    return render json: { error: "Member not found" }, status: 404 unless member
+
+    period = params[:period]&.to_sym
+    allowed_periods = %i[last_7_days previous_week this_month last_month]
+
+    unless allowed_periods.include?(period)
+      return render json: { error: "Invalid period" }, status: 400
+    end
+
+    calculator = GlucoseMetrics::Calculator.new(member: member)
+    metrics = calculator.metrics_for(period)
+
+    render json: {
+      member_id: member.id,
+      period: period,
+      metrics: metrics
+    }
+  end
+end

--- a/app/javascript/application/components/glucose_dashboard/metrics.jsx
+++ b/app/javascript/application/components/glucose_dashboard/metrics.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+
+function MetricsDashboard() {
+  const [memberId, setMemberId] = useState('');
+  const [period, setPeriod] = useState('last_7_days');
+  const [metrics, setMetrics] = useState(null);
+  const [error, setError] = useState(null);
+
+
+  const fetchMetrics = async () => {
+    try {
+      const res = await fetch(`/api/v1/metrics?member_id=${memberId}&period=${period}`);
+      const data = await res.json();
+
+      if (!res.ok) throw new Error(data.error || 'Error fetching metrics');
+      setMetrics(data.metrics);
+      setError(null);
+    } catch (err) {
+      setMetrics(null);
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="dashboard">
+      <div>
+        <label>
+          Member ID:
+          <input type="number" value={memberId} onChange={e => setMemberId(e.target.value)} />
+        </label>
+
+        <br />
+        <label>
+          Time Frame:
+          <select value={period} onChange={e => setPeriod(e.target.value)}>
+            <option value="last_7_days">Last 7 Days</option>
+            <option value="previous_week">Last Week</option>
+            <option value="this_month">This Month</option>
+            <option value="last_month">Last Month</option>
+          </select>
+        </label>
+
+        <button onClick={fetchMetrics}>Calculate</button>
+      </div>
+
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+
+      {metrics && (
+        <div className="results">
+          <h2>Metrics</h2>
+          <ul>
+            <li><strong>Average:</strong> {metrics.average}</li>
+            <li><strong>Above Range (%):</strong> {metrics.above_range}</li>
+            <li><strong>Below Range (%):</strong> {metrics.below_range}</li>
+            <li><strong>Count:</strong> {metrics.count}</li>
+            <li><strong>Change from previous period:</strong> {metrics.changes}</li>
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MetricsDashboard;

--- a/app/javascript/application/index.jsx
+++ b/app/javascript/application/index.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import MetricsDashboard from './components/glucose_dashboard/metrics'
 
 const App = () => {
   return (
     <div>
       <h1>Glucose Metrics Calculator</h1>
+      <MetricsDashboard />
     </div>
   )
 }

--- a/app/models/glucose_level.rb
+++ b/app/models/glucose_level.rb
@@ -1,2 +1,3 @@
 class GlucoseLevel < ApplicationRecord
+  belongs_to :member
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,2 +1,3 @@
 class Member < ApplicationRecord
+  has_many :glucose_levels, dependent: :destroy
 end

--- a/app/services/glucose_metrics/calculator.rb
+++ b/app/services/glucose_metrics/calculator.rb
@@ -1,0 +1,85 @@
+module GlucoseMetrics
+  class Calculator
+    attr_reader :member
+
+    def initialize(member:)
+      @member = member
+    end
+
+    def metrics_for(period)
+      readings = member.glucose_levels
+      return {} if readings.empty?
+
+      range = time_range(period)
+
+      readings_in_period = readings.select do |r|
+        local_tested_at = local_time_with_offset(r.tested_at, r.tz_offset)
+        range.cover?(local_tested_at)
+      end
+
+      return {} if readings_in_period.empty?
+
+      values = readings_in_period.map(&:value)
+      above = values.count { |v| v > 180 }
+      below = values.count { |v| v < 70 }
+
+      {
+        average: (values.sum / values.size.to_f).round(2),
+        above_range: ((above.to_f / values.size) * 100).round(2),
+        below_range: ((below.to_f / values.size) * 100).round(2),
+        count: values.size
+      }
+    end
+
+    def changes(period)
+      # not working
+      case period
+      when :last_7_days
+        metric_change(:last_7_days, :previous_week)
+      when :this_month
+        metric_change(:this_month, :last_month)
+      else
+        {}
+      end
+    end
+
+    private
+
+    def time_range(period)
+      today_utc = Time.now.utc.beginning_of_day
+
+      case period
+      when :last_7_days
+        (today_utc - 6.days)..(today_utc.end_of_day)
+      when :previous_week
+        (today_utc - 13.days)..(today_utc - 7.days).end_of_day
+      when :this_month
+        today_utc.beginning_of_month..today_utc.end_of_month
+      when :last_month
+        (today_utc - 1.month).beginning_of_month..(today_utc - 1.month).end_of_month
+      else
+        raise ArgumentError, "Unknown period: #{period}"
+      end
+    end
+
+    def local_time_with_offset(utc_time, tz_offset)
+        hours, minutes = tz_offset.split(':').map(&:to_i)
+        offset_seconds = (hours * 60 + minutes) * 60
+        offset_seconds = -offset_seconds if tz_offset.start_with?('-')
+        utc_time + offset_seconds
+    end
+
+    def metric_change(current_period, previous_period)
+      current = metrics_for(current_period)
+      previous = metrics_for(previous_period)
+
+      return {} if current.empty? || previous.empty?
+
+      {
+        average: (current[:average] - previous[:average]).round(2),
+        above_range: (current[:above_range] - previous[:above_range]).round(2),
+        below_range: (current[:below_range] - previous[:below_range]).round(2)
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,10 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
+
+  namespace :api do
+    namespace :v1 do
+      get 'metrics', to: 'metrics#show'
+    end
+  end
 end

--- a/spec/controllers/api/v1/metrics_controller_spec.rb
+++ b/spec/controllers/api/v1/metrics_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::MetricsController, type: :controller do
+  let(:member) { create(:member) }
+  let(:glucose_calculator) { instance_double(GlucoseMetrics::Calculator, metrics_for: {}, changes: {}) }
+
+  before do
+    allow(GlucoseMetrics::Calculator).to receive(:new).with(member: member).and_return(glucose_calculator)
+  end
+
+  describe 'GET #show' do
+    it 'returns metrics for the member' do
+      get :show, params: { member_id: member.id, period: 'last_7_days' }
+      
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)).to include(
+        'member_id' => member.id,
+        'period' => 'last_7_days',
+        'metrics' => {}
+      )
+    end
+
+    it 'handles member not found' do
+      expect {
+        get :show, params: { member_id: -1 }
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'returns error for invalid period' do
+      get :show, params: { member_id: member.id, period: 'invalid_period' }
+        
+      expect(response).to have_http_status(:bad_request)
+      expect(JSON.parse(response.body)).to include('error' => 'Invalid period')
+    end
+  end
+end

--- a/spec/models/glucose_level_spec.rb
+++ b/spec/models/glucose_level_spec.rb
@@ -1,4 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe GlucoseLevel do
+  it 'belongs to a member' do
+    member = create(:member)
+    glucose_level = create(:glucose_level, member: member)
+        
+    expect(glucose_level.member).to eq(member)
+  end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -4,4 +4,12 @@ RSpec.describe Member do
   it 'has a valid factory' do
     expect(create(:member)).to be_valid
   end
+
+  it 'has many glucose levels' do
+    member = create(:member)
+    glucose_level1 = create(:glucose_level, member: member)
+    glucose_level2 = create(:glucose_level, member: member)
+
+    expect(member.glucose_levels).to include(glucose_level1, glucose_level2)
+  end
 end

--- a/spec/services/glucose_metrics/calculator_spec.rb
+++ b/spec/services/glucose_metrics/calculator_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe GlucoseMetrics::Calculator do
+  let(:member) { create(:member) }
+  let(:calculator) { described_class.new(member: member) }
+  
+  describe '#metrics_for' do
+    context 'when there are no glucose readings' do
+      it 'returns an empty hash' do
+        expect(calculator.metrics_for(:this_week)).to eq({})
+      end
+    end
+    
+    context 'when there are glucose readings' do
+      before do
+        create(:glucose_level, member: member, value: 100, tested_at: 1.day.ago)
+      end
+      
+      it 'calculates metrics correctly for this week' do
+        metrics = calculator.metrics_for(:last_7_days)
+        expect(metrics[:average]).to eq(100.0)
+        expect(metrics[:above_range]).to eq(0.0)
+        expect(metrics[:below_range]).to eq(0.0)
+        expect(metrics[:count]).to eq(1)
+      end
+
+      it 'calculates metrics correctly for the previous week' do
+        create(:glucose_level, member: member, value: 200, tested_at: 8.days.ago)
+        metrics = calculator.metrics_for(:previous_week)
+        expect(metrics[:average]).to eq(200.0)
+        expect(metrics[:above_range]).to eq(100.0)
+        expect(metrics[:below_range]).to eq(0.0)
+        expect(metrics[:count]).to eq(1)
+      end
+
+      it 'calculates metrics correctly for this month' do
+        create(:glucose_level, member: member, value: 150, tested_at: 5.days.ago)
+        metrics = calculator.metrics_for(:this_month)
+        expect(metrics[:average]).to eq(125.0)
+        expect(metrics[:above_range]).to eq(0.0)
+        expect(metrics[:below_range]).to eq(0.0)
+        expect(metrics[:count]).to eq(2)
+      end
+
+      it 'calculates metrics correctly for last month' do
+        create(:glucose_level, member: member, value: 60, tested_at: 35.days.ago)
+        metrics = calculator.metrics_for(:last_month)
+        expect(metrics[:average]).to eq(60.0)
+        expect(metrics[:above_range]).to eq(0.0)
+        expect(metrics[:below_range]).to eq(100.0)
+        expect(metrics[:count]).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Screen recording:
https://github.com/user-attachments/assets/0134c88c-2442-4c53-8f8c-0d40d14326e6

## Assumptions:
- User testing knows seed data has Member of ID 1

## If I had more time:
- The calculated change was functional and working as expected prior to the implementation of the form for member ID and time frame input. Would like to make this work in the future.
- Improve UI/UX design
- Optimize performance by improving caching through memoization or by refining db queries
- Update to allow users to input any custom time frame, rather than being limited to predefined options
- Improve error handling to provide clearer feedback when a non-existent memebr ID is entered
- Add notes in codebase to explain logic
- Double check the calculation logic, as I initially assumed ChatGPT’s outputs were accurate and didn’t spend much time validating them

## AI Prompts:
- Utilized copilot in VSCode to help with spec files
- Utilized ChatGPT by copy/pasting readme and having it generate initial app setup ([ChatGPT-Glucose Metrics Calculator Setup.md](https://github.com/user-attachments/files/20634589/ChatGPT-Glucose.Metrics.Calculator.Setup.md))

